### PR TITLE
Provide utility interface to tether extensions

### DIFF
--- a/cmd/tether/attach.go
+++ b/cmd/tether/attach.go
@@ -150,7 +150,7 @@ func (t *attachServerSSH) Enabled() bool {
 	return atomic.LoadInt32(&t.enabled) == 1
 }
 
-func (t *attachServerSSH) Start() error {
+func (t *attachServerSSH) Start(system tether.System) error {
 	defer trace.End(trace.Begin(""))
 
 	return nil

--- a/cmd/tether/haveged_linux.go
+++ b/cmd/tether/haveged_linux.go
@@ -49,7 +49,7 @@ func NewHaveged() *Haveged {
 }
 
 // Start implementation of the tether.Extension interface
-func (h *Haveged) Start() error {
+func (h *Haveged) Start(system tether.System) error {
 	log.Infof("Starting haveged")
 
 	var err error

--- a/lib/tether/interfaces.go
+++ b/lib/tether/interfaces.go
@@ -56,6 +56,23 @@ type Operations interface {
 	HandleUtilityExit(pid, exitCode int) bool
 }
 
+// System is a very preliminary interface that provides extensions with a means by which to
+// perform system style operations.
+// This should be designed with intent to provide sufficient abstraction that vic-init, tether
+// can be run by vcsim. Odds are that a significant portion of the methods on this interface
+// will be defined in vcsim and this interface will simply embed the vcsim interface.
+// There may well be overlap with shared.Sys that needs to be resolved
+//
+// For now its sole purpose is to allow extensions access to the specific portions of
+// BaseOperations that they actively use.
+type System interface {
+	// LaunchUtility starts a process and provides a way to block on completion and retrieve
+	// it's exit code. This is needed to co-exist with a childreaper.
+	LaunchUtility(UtilityFn) (<-chan int, error)
+
+	MountLabel(ctx context.Context, label, target string) error
+}
+
 // Tether presents the consumption interface for code needing to run a tether
 type Tether interface {
 	Start() error
@@ -67,7 +84,7 @@ type Tether interface {
 // Extension is a very simple extension interface for supporting code that need to be
 // notified when the configuration is reloaded.
 type Extension interface {
-	Start() error
+	Start(System) error
 	Reload(config *ExecutorConfig) error
 	Stop() error
 }

--- a/lib/tether/tether.go
+++ b/lib/tether/tether.go
@@ -158,7 +158,7 @@ func (t *tether) setup() error {
 
 	for name, ext := range t.extensions {
 		log.Infof("Starting extension %s", name)
-		err := ext.Start()
+		err := ext.Start(t.ops)
 		if err != nil {
 			log.Errorf("Failed to start extension %s: %s", name, err)
 			return err

--- a/lib/tether/toolbox.go
+++ b/lib/tether/toolbox.go
@@ -56,6 +56,9 @@ type Toolbox struct {
 	authIDs map[string]struct{}
 
 	stop chan struct{}
+
+	// System interface for basic operations
+	baseOp System
 }
 
 var (
@@ -78,7 +81,7 @@ func NewToolbox() *Toolbox {
 }
 
 // Start implementation of the tether.Extension interface
-func (t *Toolbox) Start() error {
+func (t *Toolbox) Start(system System) error {
 	t.stop = make(chan struct{})
 	on := make(chan struct{})
 
@@ -87,6 +90,8 @@ func (t *Toolbox) Start() error {
 		close(on)
 		return nil
 	}
+
+	t.baseOp = system
 
 	err := t.Service.Start()
 	if err != nil {
@@ -147,9 +152,16 @@ func (t *Toolbox) InContainer() *Toolbox {
 	cmd.Authenticate = t.containerAuthenticate
 	cmd.ProcessStartCommand = t.containerStartCommand
 
+	ar := func(u *url.URL, r *tar.Reader) error {
+		return toolboxOverrideArchiveRead(t.baseOp, u, r)
+	}
+	aw := func(u *url.URL, w *tar.Writer) error {
+		return toolboxOverrideArchiveWrite(t.baseOp, u, w)
+	}
+
 	cmd.FileServer.RegisterFileHandler(hgfs.ArchiveScheme, &hgfs.ArchiveHandler{
-		Read:  toolboxOverrideArchiveRead,
-		Write: toolboxOverrideArchiveWrite,
+		Read:  ar,
+		Write: aw,
 	})
 
 	return t
@@ -270,7 +282,7 @@ func (t *Toolbox) halt() error {
 }
 
 // toolboxOverrideArchiveRead is the online DataSink Override Handler
-func toolboxOverrideArchiveRead(u *url.URL, tr *tar.Reader) error {
+func toolboxOverrideArchiveRead(system System, u *url.URL, tr *tar.Reader) error {
 
 	// special behavior when using disk-labels and filterspec
 	diskLabel := u.Query().Get(shared.DiskLabelQueryName)
@@ -284,7 +296,7 @@ func toolboxOverrideArchiveRead(u *url.URL, tr *tar.Reader) error {
 			return err
 		}
 
-		diskPath, err := mountDiskLabel(op, diskLabel)
+		diskPath, err := mountDiskLabel(op, system, diskLabel)
 		if err != nil {
 			op.Errorf(err.Error())
 			return err
@@ -305,7 +317,7 @@ func toolboxOverrideArchiveRead(u *url.URL, tr *tar.Reader) error {
 }
 
 // toolboxOverrideArchiveWrite is the Online DataSource Override Handler
-func toolboxOverrideArchiveWrite(u *url.URL, tw *tar.Writer) error {
+func toolboxOverrideArchiveWrite(system System, u *url.URL, tw *tar.Writer) error {
 
 	// special behavior when using disk-labels and filterspec
 	diskLabel := u.Query().Get(shared.DiskLabelQueryName)
@@ -325,7 +337,7 @@ func toolboxOverrideArchiveWrite(u *url.URL, tw *tar.Writer) error {
 		}
 
 		// get the container fs mount
-		diskPath, err := mountDiskLabel(op, diskLabel)
+		diskPath, err := mountDiskLabel(op, system, diskLabel)
 		if err != nil {
 			op.Errorf(err.Error())
 			return err
@@ -383,7 +395,7 @@ func toolboxOverrideArchiveWrite(u *url.URL, tw *tar.Writer) error {
 	return defaultArchiveHandler.Write(u, tw)
 }
 
-func mountDiskLabel(op trace.Operation, label string) (string, error) {
+func mountDiskLabel(op trace.Operation, system System, label string) (string, error) {
 	// We know the vmdk will always be attached at '/'
 	if label == "containerfs" {
 		return "/", nil
@@ -396,7 +408,7 @@ func mountDiskLabel(op trace.Operation, label string) (string, error) {
 		return "", fmt.Errorf("failed to create mountpoint %s: %s", tmpDir, err)
 	}
 
-	err = baseOp.MountLabel(op, label, tmpDir)
+	err = system.MountLabel(op, label, tmpDir)
 	if err != nil {
 		os.Remove(tmpDir)
 		op.Errorf("failed to mount label %s at %s: %s", label, tmpDir, err)

--- a/pkg/logmgr/logmgr.go
+++ b/pkg/logmgr/logmgr.go
@@ -155,7 +155,7 @@ func (lm *LogManager) AddLogRotate(logFilePath string, ri RotateInterval, maxSiz
 func (lm *LogManager) Reload(*tether.ExecutorConfig) error { return nil }
 
 // Start log rotate loop.
-func (lm *LogManager) Start() error {
+func (lm *LogManager) Start(system tether.System) error {
 	if len(lm.logFiles) == 0 {
 		lm.op.Errorf("Attempt to start logrotate with no log files configured.")
 		return nil


### PR DESCRIPTION
This is a short term mechanism to provide a basic utility interface to
tether extensions. In this case it's only enough for launching utility
processes and getting the exit code without racing with the childReaper,
and to mount disks by label.

This needs to be properly designed and planned for use with vcsim,
allowing abstraction of the base systemn interactions.

